### PR TITLE
fix: returned package contents was always empty

### DIFF
--- a/internal/impl/contents/retrieve_contents.go
+++ b/internal/impl/contents/retrieve_contents.go
@@ -1,17 +1,17 @@
 package contents
 
 import (
-	"github.com/fdaines/arch-go/internal/model"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/fdaines/arch-go/internal/model"
 )
 
 func retrieveContents(pkg *model.PackageInfo, mainPackage string) (*PackageContents, error) {
-	var methods, functions, interfaces, structs int
 	path, err := os.Getwd()
 	if err != nil {
 		panic(err)
@@ -32,12 +32,7 @@ func retrieveContents(pkg *model.PackageInfo, mainPackage string) (*PackageConte
 		packageContents = inspectFile(node, packageContents)
 	}
 
-	return &PackageContents{
-		Methods:    methods,
-		Functions:  functions,
-		Interfaces: interfaces,
-		Structs:    structs,
-	}, nil
+	return packageContents, nil
 }
 
 func inspectFile(node *ast.File, contents *PackageContents) *PackageContents {


### PR DESCRIPTION
The `contentsRules` would always return true, no matter what rules you applied. I dug into the code and found that an empty struct was returned instead of the proper populated object. This PR addresses this issue.