### PR TITLE
Fixes #35 - adds fix + tests to check if the right error code is returned w…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,5 +99,5 @@ func runRootCommand(out io.Writer) bool {
 	report := reports.GenerateReport(result, moduleInfo, *configuration)
 	reports.DisplayResult(report, out)
 
-	return true
+	return result.Passes
 }


### PR DESCRIPTION
…hen api.CheckArchitecture result passed is true / false

@fdaines I needed to monkeypatch the `api.CheckArchitecture` result, as it seems that it returns `passed` even when nothing gets executed (I tried with a broken arch-go.yml, but due to it not being on top level of the repo, it couldn't find any packages I guess. That might be worth a follow-up ticket, so it does either return a value or false instead if it does not validate anything.)